### PR TITLE
1.3.0

### DIFF
--- a/.travis.mk
+++ b/.travis.mk
@@ -30,6 +30,7 @@ $(SCRIPTDIR)/packpack:
 	$(info -------------------------------------------------------------------)
 	$(info Patching packpak...)
 	$(shell cd $(SCRIPTDIR)/packpack && git apply $(SCRIPTDIR)/gh-84.patch)
+	$(shell cd $(SCRIPTDIR)/packpack && git apply $(SCRIPTDIR)/gh-97.patch)
 	$(info -------------------------------------------------------------------)
 
 .PHONY: source

--- a/.travis.mk
+++ b/.travis.mk
@@ -26,7 +26,8 @@ include $(SCRIPTDIR)/builder/check.mk
 include $(SCRIPTDIR)/builder/patching.mk
 
 $(SCRIPTDIR)/packpack:
-	$(shell git clone -q --depth=1 $(PACK_REPO) -b $(PACK_BRANCH) $(SCRIPTDIR)/packpack)
+	$(shell git clone --depth=1 --branch=$(PACK_BRANCH) $(PACK_REPO) $(SCRIPTDIR)/packpack)
+	$(shell cd $(SCRIPTDIR)/packpack && git checkout -qf $(PACK_COMMIT))
 	$(info -------------------------------------------------------------------)
 	$(info Patching packpak...)
 	$(shell cd $(SCRIPTDIR)/packpack && git apply $(SCRIPTDIR)/gh-84.patch)

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@
 # obtain it through the world-wide-web, please send an email
 # to license@phalconphp.com so we can send you a copy immediately.
 #
-# Authors: Phalcon Framework Team <team@phalconphp.com>
+# Authors: Phalcon Team <team@phalconphp.com>
 #
 
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ env:
         - STABLE_BRANCH=v3.4.0
         - NIGHTLY_BRANCH=3.4.x
         # This should be increased to reb-build and push package
-        - STABLE_BUILD_VERSION=2
+        - STABLE_BUILD_VERSION=3
         - NIGHTLY_BUILD_VERSION=$TRAVIS_BUILD_NUMBER
         - TARGET=package
         - RE2C_VERSION="1.0.3"
@@ -60,6 +60,9 @@ env:
         - OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH
         - OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.1
         - OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.2
+        - OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH
+        - OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.1
+        - OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.2
         - OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH
         - OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.0
         - OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.1
@@ -76,6 +79,9 @@ env:
         - OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH
         - OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
         - OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.2
+        - OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH
+        - OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
+        - OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.2
         - OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH
         - OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.0
         - OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
@@ -96,6 +102,9 @@ matrix:
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.2
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.2
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.0
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
@@ -112,6 +121,10 @@ matrix:
           php: 5.5
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH
           php: 5.5
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH
+          php: 5.5
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH
+          php: 5.5
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH
           php: 5.5
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.0
@@ -132,6 +145,10 @@ matrix:
           php: 5.5
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
           php: 5.5
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.1
+          php: 5.5
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
+          php: 5.5
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.1
           php: 5.5
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
@@ -147,6 +164,10 @@ matrix:
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.2
           php: 5.5
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.2
+          php: 5.5
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.2
+          php: 5.5
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.2
           php: 5.5
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.2
           php: 5.5
@@ -168,6 +189,10 @@ matrix:
           php: 5.6
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH
           php: 5.6
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH
+          php: 5.6
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH
+          php: 5.6
         - env: OS=debian DIST=stretch PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH
           php: 5.6
         - env: OS=debian DIST=stretch PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH
@@ -184,6 +209,10 @@ matrix:
           php: 5.6
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
           php: 5.6
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.1
+          php: 5.6
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
+          php: 5.6
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.1
           php: 5.6
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
@@ -199,6 +228,10 @@ matrix:
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.2
           php: 5.6
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.2
+          php: 5.6
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.2
+          php: 5.6
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.2
           php: 5.6
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.2
           php: 5.6
@@ -224,6 +257,10 @@ matrix:
           php: 7.0
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
           php: 7.0
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.1
+          php: 7.0
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
+          php: 7.0
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.1
           php: 7.0
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
@@ -239,6 +276,10 @@ matrix:
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.2
           php: 7.0
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.2
+          php: 7.0
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.2
+          php: 7.0
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.2
           php: 7.0
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.2
           php: 7.0
@@ -268,6 +309,14 @@ matrix:
           php: 7.1
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.2
           php: 7.1
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH
+          php: 7.1
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.2
+          php: 7.1
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH
+          php: 7.1
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.2
+          php: 7.1
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH
           php: 7.1
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.0
@@ -307,6 +356,14 @@ matrix:
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH
           php: 7.2
         - env: OS=ubuntu DIST=xenial PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
+          php: 7.2
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH
+          php: 7.2
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH PHP_VERSION=7.1
+          php: 7.2
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH
+          php: 7.2
+        - env: OS=ubuntu DIST=bionic PACKAGE=deb CLONE_BRANCH=$NIGHTLY_BRANCH PHP_VERSION=7.1
           php: 7.2
         - env: OS=debian DIST=jessie PACKAGE=deb CLONE_BRANCH=$STABLE_BRANCH
           php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ env:
         - STABLE_BRANCH=v3.4.0
         - NIGHTLY_BRANCH=3.4.x
         # This should be increased to reb-build and push package
-        - STABLE_BUILD_VERSION=3
+        - STABLE_BUILD_VERSION=4
         - NIGHTLY_BUILD_VERSION=$TRAVIS_BUILD_NUMBER
         - TARGET=package
         - RE2C_VERSION="1.0.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ env:
         - STABLE_BRANCH=v3.4.0
         - NIGHTLY_BRANCH=3.4.x
         # This should be increased to reb-build and push package
-        - STABLE_BUILD_VERSION=4
+        - STABLE_BUILD_VERSION=5
         - NIGHTLY_BUILD_VERSION=$TRAVIS_BUILD_NUMBER
         - TARGET=package
         - RE2C_VERSION="1.0.3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added ability to build packages for Ubuntu 18.04
 - Added a common Debian/Ubuntu prebuild.sh script
 
+### Fixed
+- Added `TMPDIR` variable to the build container [packpack/packpack#97](https://github.com/packpack/packpack/issues/97)
+
 ## [1.2.3] - 2018-03-10
 ### Fixed
-- Patching packpack due to https://github.com/packpack/packpack/pull/84#issuecomment-371755389
+- Patching packpack due to [packpack/packpack#84](https://github.com/packpack/packpack/pull/84#issuecomment-371755389)
 
 ## [1.2.2] - 2017-07-10
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Added ability to build packages for Ubuntu 18.04
+- Added a common Debian/Ubuntu prebuild.sh script
 
 ## [1.2.3] - 2018-03-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.3.0] - 2018-07-28
 ### Added
-- Added ability to build packages for Ubuntu 18.04
-- Added a common Debian/Ubuntu prebuild.sh script
+- Added ability to build packages for Ubuntu 18.04 [phalcongelist/packagecloud#27](https://github.com/phalcongelist/packagecloud/issues/27), [phalcon/cphalcon#13376](https://github.com/phalcon/cphalcon/issues/13376)
+- Added a common Debian/Ubuntu `prebuild.sh` script
+
+### Changed
+- Freezed packpack version to make sure that we use the same packpack always
 
 ### Fixed
 - Added `TMPDIR` variable to the build container [packpack/packpack#97](https://github.com/packpack/packpack/issues/97)
@@ -54,7 +57,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Ubuntu 14.04-16.04, Debian 8.5-9 and CentOS 7.2 by using
 [Packpack](https://github.com/packpack/packpack).
 
-[Unreleased]: https://github.com/phalcongelist/packagecloud/compare/v1.2.3...HEAD
+[Unreleased]: https://github.com/phalcongelist/packagecloud/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/phalcongelist/packagecloud/compare/v1.2.3...v1.3.0
 [1.2.3]: https://github.com/phalcongelist/packagecloud/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/phalcongelist/packagecloud/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/phalcongelist/packagecloud/compare/v1.2.0...v1.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added ability to build packages for Ubuntu 18.04
 
 ## [1.2.3] - 2018-03-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [1.3.0] - 2018-07-28
 ### Added
 - Added ability to build packages for Ubuntu 18.04
 - Added a common Debian/Ubuntu prebuild.sh script

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 New BSD License
 
-Copyright (c) 2011-present, Phalcon Framework Team
+Copyright (c) 2011-present, Phalcon Team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Installation/configuration details for each version and operating system [can be
 | `xenial`  | 16.04 LTS  | `3.0.0` - `3.4.0` | `7.0.x`                |
 | `xenial`  | 16.04 LTS  | `3.1.2` - `3.4.0` | `7.1.x`                |
 | `xenial`  | 16.04 LTS  | `3.3.0` - `3.4.0` | `7.2.x`                |
+| `bionic`  | 18.04 LTS  | `3.4.0`           | `7.0.x`                |
+| `bionic`  | 18.04 LTS  | `3.4.0`           | `7.1.x`                |
+| `bionic`  | 18.04 LTS  | `3.4.0`           | `7.2.x`                |
 
 ### Debian
 

--- a/builder/config.mk
+++ b/builder/config.mk
@@ -19,6 +19,7 @@ CHANGELOG_TEXT=Automated build. See details at release page https://github.com/p
 
 PACK_REPO=https://github.com/packpack/packpack.git
 PACK_BRANCH=master
+PACK_COMMIT=30ff7b51654c19b8919d01ca8d4aa480e87e8241
 
 DOCKER_REPO=phalconphp/build
 

--- a/builder/config.mk
+++ b/builder/config.mk
@@ -35,7 +35,7 @@ STABLE_BUILD_VERSION?=1
 FEDORA:=fedora-rawhide fedora24 fedora23
 CENTOS:=centos7 centos6
 DEBIAN:=debian-sid debian-stretch debian-jessie debian-wheezy
-UBUNTU:=ubuntu-yakkety ubuntu-xenial ubuntu-wily ubuntu-trusty ubuntu-precise
+UBUNTU:=ubuntu-bionic ubuntu-xenial ubuntu-trusty
 
 DEBS:=$(DEBIAN) $(UBUNTU)
 RPMS:=$(FEDORA) $(CENTOS)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
 php-phalcon (3.1.0-1) stable; urgency=low
 
- --  Serghei Iakovlev <serghei@phalconphp.com>  Wed, 22 Mar 2017 21:30:00 +0300
+  * Automated build. See details at release page
+    https://github.com/phalcon/cphalcon/releases
+
+ -- Serghei Iakovlev <serghei@phalconphp.com>  Wed, 22 Mar 2017 21:30:00 +0300

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,13 +1,13 @@
 Format: http://dep.debian.net/deps/dep5/
 Debianized-By: Serghei Iakovlev <serghei@phalconphp.com>
 Upstream-Name: php-phalcon
-Upstream-Contact: Phalcon Framework Team <team@phalconphp.com>
+Upstream-Contact: Phalcon Team <team@phalconphp.com>
 Source: https://github.com/phalcon/cphalcon
 
 Files: *
-Copyright: Copyright (c) 2011-present Phalcon Framework Team <team@phalconphp.com>
+Copyright: Copyright (c) 2011-present Phalcon Team <team@phalconphp.com>
 License: BSD-3-clause
- Copyright (c) 2011-present, Phalcon Framework Team <team@phalconphp.com>
+ Copyright (c) 2011-present, Phalcon Team <team@phalconphp.com>
  All rights reserved.
  .
  Redistribution and use in source and binary forms, with or without

--- a/debian/prebuild.sh
+++ b/debian/prebuild.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# This line instructs debconf to store in its database an answer for
+# the program debconf. If (the running program) debconf later asks
+# (the database of answers) debconf what is my frontend the answer
+# will be frontend is Noninteractive.
+#
+# It has nothing to do with the interactivity of bash.
+echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections

--- a/gh-97.patch
+++ b/gh-97.patch
@@ -1,0 +1,12 @@
+diff --git a/packpack b/packpack
+index 6f4c80f..1659773 100755
+--- a/packpack
++++ b/packpack
+@@ -155,6 +155,7 @@ docker run \
+         --entrypoint=/build/userwrapper.sh \
+         -e XDG_CACHE_HOME=/cache \
+         -e CCACHE_DIR=/cache/ccache \
++        -e TMPDIR=/tmp \
+         --volume "${CACHE_DIR}:/cache" \
+         ${DOCKER_REPO}:${DOCKER_IMAGE} \
+         make -f /pack/Makefile -C /source BUILDDIR=/build -j "$@"


### PR DESCRIPTION
##### Added
- Added ability to build packages for Ubuntu 18.04 [phalcongelist/packagecloud#27](https://github.com/phalcongelist/packagecloud/issues/27), [phalcon/cphalcon#13376](https://github.com/phalcon/cphalcon/issues/13376)
- Added a common Debian/Ubuntu `prebuild.sh` script

##### Changed
- Freezed packpack version to make sure that we use the same packpack always

##### Fixed
- Added `TMPDIR` variable to the build container [packpack/packpack#97](https://github.com/packpack/packpack/issues/97)
